### PR TITLE
Add params parameter to show() and toggle()

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -38,10 +38,10 @@ export type VueFinalModalProperty = {
   openedModals: VueFinalModalInfo[]
   modals: VueFinalModalInfo[]
   get(name: string): VueFinalModalInfo | undefined
-  show(name: string): void
+  show(name: string, params?: any): void
   hide(name: string): void
   hideAll(): void
-  toggle(name: string, show: boolean): void
+  toggle(name: string, show: boolean, params?: any): void
 }
 
 declare module '@vue/runtime-core' {


### PR DESCRIPTION
As stated in the docs, `show()` and `toggle()` accept a parameter called `params`. (https://vue-final-modal.org/#vfmshowname-params) While this is technically working, there is no TypeScript Support for this yet.