### PR TITLE
feat: allow importing the component directly

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,8 @@
 import Plugin from './Plugin'
 
+import VueFinalModal from './VueFinalModal.vue'
+import ModalsContainer from './ModalsContainer.vue'
+
+export { Plugin, VueFinalModal, ModalsContainer }
+
 export default Plugin


### PR DESCRIPTION
Hey Hunter.
I really like Vue Final Modal.
but I have one part I wanna discuss with you: the way to install the plugin is currently only available via the Vue install method.
I am of the mindset that the best way to import Vue components from a library is directly importing the component itself and register it where you want to use it
Let me give you an example, it would look something like this:

```vue
<template>
  <div>
    <VueFinalModal>
      content...
    </VueFinalModal>
  </div>
</template>

<script>
import { VueFinalModal } from 'vue-final-modal'

export default {
  components: { VueFinalModal }
}
</script>
```
this way it's also easier to in the future have better IDE support for typescript and prop descriptions and auto completion etc.

What do you think? Let's discuss.