### PR TITLE
Fix Nuxt example

### DIFF
--- a/docs/content/en/setup.md
+++ b/docs/content/en/setup.md
@@ -116,6 +116,7 @@ Vue.use(vfmPlugin)
 - **Write a plugin `vue-final-modal.js`**
 
 ```js[plugins/vue-final-modal.js]
+import Vue from 'vue'
 import { vfmPlugin } from 'vue-final-modal/lib'
 
 Vue.use(vfmPlugin)


### PR DESCRIPTION
The Nuxt plugin MUST import Vue, otherwise the Nuxt app won't work AND Nuxt will NOT show any errors. Which is very inconvenient... so better add it.