### PR TITLE
Add import statement and component attribute definition

### DIFF
--- a/docs/content/en/examples/recommend.md
+++ b/docs/content/en/examples/recommend.md
@@ -10,9 +10,11 @@ version: 2
 
 <alert>
 
-You can create a `higher-order component` easily and can customize `template`, `script` and `style` based on your needs.
+You can create a `higher-order component` easily and can customize `template`, `script` and `style` to your needs.
 
 </alert>
+
+Put this modal template in a location like `@/components/hoc/CustomModal.vue`:
 
 ### CustomModal.vue
 
@@ -125,7 +127,10 @@ export default {
 ```
 ```vue
 <script>
+import CurstomModal from '@/components/hoc/CustomModal'
+
 export default {
+  components: { CustomModal },
   data: () => ({
     show: false
   }),

--- a/docs/content/en/examples/recommend.md
+++ b/docs/content/en/examples/recommend.md
@@ -127,7 +127,7 @@ export default {
 ```
 ```vue
 <script>
-import CurstomModal from '@/components/hoc/CustomModal'
+import CustomModal from '@/components/hoc/CustomModal'
 
 export default {
   components: { CustomModal },


### PR DESCRIPTION
Without importing the modal component, this example would not work. Therefore add it to the main template.

Also, give the reader more information about where the modal component can be located (provide a path as example, from which the component will be imported).
