### PR TITLE
fix(type): exports `$vfm` through the type definition file for typescript imports

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -108,5 +108,7 @@ declare module '@vue/runtime-core' {
   }
 }
 
+export const $vfm: VueFinalModalProperty;
+
 declare const VueFinalModal: VueFinalModal
 export default VueFinalModal


### PR DESCRIPTION
Fixes #173

Exporting a `$vfm` const within the `index.d.ts` should be sufficient to correctly import

```ts
import { $vfm } from 'vue-final-modal'
```

which currently emits the following error:

```
Module '"vue-final-modal"' has no exported member '$vfm'. Did you mean to use 'import $vfm from "vue-final-modal"' instead?
```