### PR TITLE
Expose `id` to add dynamic modal with custom symbol

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -9,6 +9,10 @@ export class VueFinalModalComponant extends Vue {
 
 export interface DynamicModalOptions {
   /**
+   * Custom id rather than using Symbol('dynamicModal')
+   */
+  id?: symbol,
+  /**
    * modal component
    */
   component?: string | Component | AsyncComponent
@@ -59,7 +63,6 @@ export interface DynamicModalOptions {
 
 interface DynamicModalData extends DynamicModalOptions {
   value: boolean
-  id: symbol
   params: any
 }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -73,7 +73,7 @@ export interface VueFinalModalProperty {
   get(...names: string[]): VueFinalModalComponant[]
 
   show(name: string, params?: any): void
-  show(modal: DynamicModalOptions, params?: any): void
+  show(modal: DynamicModalOptions, params?: any): Promise<any[]>
 
   hide(...names: string[]): void
   hideAll(): void


### PR DESCRIPTION
1. Expose `id` on `DynamicModalOptions`

I have a concern to expose the `id` for `DynamicModalOptions` in Typescript so we could identify the modal and doing further steps, for example I need to close the specific modal rather than closing all modals.

```ts
import PopupInfo from './PopupInfo';

const modalId = Symbol('myModal')
$vfm.show({
  id: modalId,
  component: DummyModal,
  bind: {
    title: 'My Awesome Modal',
  },
  on: {
    closeTheModal: () => {
      const modal = getModalComponent(modalId) // getting the dynamic modal
      if (modal) {
        (modal as any).value = false // closing the specific dynamic modal
      }
    }
  }
});

const getModalComponent = (modalId: symbol): any | null => {
  let foundModal = null;
  for (const modal of $vfm.dynamicModals) {
    if (modal.id === modalId) {
      foundModal = modal;
      break;
    }
  }

  return foundModal;
};
```

2. Fix the return type as Promise value, related to [this Issue](https://github.com/vue-final/vue-final-modal/issues/189)