### PR TITLE
feat: add exports setting in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,13 @@
   "unpkg": "dist/VueFinalModal.umd.js",
   "jsdelivr": "dist/VueFinalModal.umd.js",
   "types": "types/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.esm.mjs",
+      "require": "./dist/index.cje.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "files": [
     "lib",
     "dist",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "exports": {
     ".": {
       "import": "./dist/index.esm.mjs",
-      "require": "./dist/index.cje.js",
+      "require": "./dist/index.umd.js",
       "types": "./dist/index.d.ts"
     }
   },

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   "types": "types/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/index.esm.mjs",
-      "require": "./dist/index.umd.js",
+      "import": "./dist/VueFinalModal.esm.js",
+      "require": "./dist/VueFinalModal.umd.js",
       "types": "./dist/index.d.ts"
     }
   },


### PR DESCRIPTION
In `^vue-final-modal@3.4.8`, work with `^nuxt@3.0.0-rc.8` will throw error like below. 

```
TypeError: Cannot read properties of undefined (reading 'withScopeId')
    at file:///Users/path/project/node_modules/vue-final-modal/dist/VueFinalModal.umd.js:1347:21
    at file:///Users/path/project/node_modules/vue-final-modal/dist/VueFinalModal.umd.js:4:78
    at file:///Users/path/project/node_modules/vue-final-modal/dist/VueFinalModal.umd.js:5:2
    at ModuleJob.run (node:internal/modules/esm/module_job:183:25)
    at async Loader.import (node:internal/modules/esm/loader:178:24)
    at async __instantiateModule__ (file:///Users/path/project/.nuxt/dist/server/server.mjs:136034:3)
```

We need to use esm with nuxt 3, but the current import is umd.

Maybe we can add conditional exports setting at package.json to resolve this error ? I have tested on my work project with no issues.
