### PR TITLE
feat: `useModal()` slots allow passing components directly

### DIFF
--- a/docs/components/content/BottomSheetPreview.vue
+++ b/docs/components/content/BottomSheetPreview.vue
@@ -3,7 +3,7 @@ import { ModalsContainer, useModal } from 'vue-final-modal'
 import BottomSheet from './BottomSheet.vue'
 
 const { open } = useModal({
-  component: markRaw(BottomSheet),
+  component: BottomSheet,
 })
 </script>
 

--- a/docs/components/content/DragResizeModalPreview.vue
+++ b/docs/components/content/DragResizeModalPreview.vue
@@ -3,7 +3,7 @@ import { ModalsContainer, useModal } from 'vue-final-modal'
 import DragResizeModal from './DragResizeModal.vue'
 
 const { open } = useModal({
-  component: markRaw(DragResizeModal),
+  component: DragResizeModal,
 })
 </script>
 

--- a/docs/components/content/FullscreenPreview.vue
+++ b/docs/components/content/FullscreenPreview.vue
@@ -3,7 +3,7 @@ import { ModalsContainer, useModal } from 'vue-final-modal'
 import Fullscreen from './Fullscreen.vue'
 
 const { open } = useModal({
-  component: markRaw(Fullscreen),
+  component: Fullscreen,
 })
 </script>
 

--- a/docs/components/content/LoginFormModalPreview.vue
+++ b/docs/components/content/LoginFormModalPreview.vue
@@ -3,7 +3,7 @@ import { ModalsContainer, useModal } from 'vue-final-modal'
 import LoginFormModal from './LoginFormModal.vue'
 
 const { open, close } = useModal<InstanceType<typeof LoginFormModal>['$props']>({
-  component: markRaw(LoginFormModal),
+  component: LoginFormModal,
   attrs: {
     onSubmit(formData) {
       alert(JSON.stringify(formData, null, 2))

--- a/docs/components/content/NestedModalPreview.vue
+++ b/docs/components/content/NestedModalPreview.vue
@@ -3,7 +3,7 @@ import { ModalsContainer, useModal } from 'vue-final-modal'
 import ConfirmModal from './ConfirmModal.vue'
 
 const confirm1 = useModal({
-  component: markRaw(ConfirmModal),
+  component: ConfirmModal,
   attrs: {
     title: 'The first confirm modal',
     onConfirm() {
@@ -16,7 +16,7 @@ const confirm1 = useModal({
 })
 
 const confirm2 = useModal({
-  component: markRaw(ConfirmModal),
+  component: ConfirmModal,
   attrs: {
     title: 'The second confirm modal',
     onConfirm() {

--- a/docs/components/content/PlainCssConfirmModalPreview.vue
+++ b/docs/components/content/PlainCssConfirmModalPreview.vue
@@ -3,7 +3,7 @@ import { ModalsContainer, useModal } from 'vue-final-modal'
 import PlainCssConfirmModal from './PlainCssConfirmModal.vue'
 
 const { open, close } = useModal({
-  component: markRaw(PlainCssConfirmModal),
+  component: PlainCssConfirmModal,
   attrs: {
     title: 'Hello World!',
     onConfirm() {

--- a/docs/components/content/UseModalPreview.vue
+++ b/docs/components/content/UseModalPreview.vue
@@ -5,7 +5,7 @@ import ConfirmModal from './ConfirmModal.vue'
 const { open, close } = useModal<
   InstanceType<typeof ConfirmModal>['$props']
 >({
-  component: markRaw(ConfirmModal),
+  component: ConfirmModal,
   attrs: {
     title: 'Hello World!',
     onConfirm() {

--- a/docs/content/2.get-started/1.guide/3.migration-guide.md
+++ b/docs/content/2.get-started/1.guide/3.migration-guide.md
@@ -81,7 +81,7 @@ So this:
 
 ```ts
 this.$vfm.show({
-  component: markRaw(ConfirmModal),
+  component: ConfirmModal,
   bind: {
     name: 'ConfirmModalName'
   },
@@ -103,7 +103,7 @@ Will be re-written as this:
 
 ```ts
 const { open, close } = useModal<InstanceType<typeof ConfirmModal>['$props']>({
-  component: markRaw(ConfirmModal),
+  component: ConfirmModal,
   attrs: {
     title: 'Hello World!',
     onConfirm() {

--- a/docs/content/2.get-started/1.guide/4.types.md
+++ b/docs/content/2.get-started/1.guide/4.types.md
@@ -20,22 +20,28 @@ export type ModalId = number | string | symbol
 export type StyleValue = string | CSSProperties | (string | CSSProperties)[]
 ```
 
+## ModalSlot
+
+```ts
+export type ModalSlot<T extends Record<string, any> = {}> = string | Component | {
+  component: Component
+  attrs?: T
+}
+```
+
 ## UseModalOptionsPrivate
 
 ```ts
 export type UseModalOptionsPrivate<
-  ModalProps extends ComponentProps,
-  DefaultSlotProps extends ComponentProps,
+  ModalProps extends ComponentProps = {},
+  DefaultSlotProps extends ComponentProps = {},
 > = {
   context?: Vfm
   component: Component
   attrs?: ModalProps
   slots?: {
-    default: string | {
-      component: Component
-      attrs?: DefaultSlotProps
-    }
-    [key: string]: any
+    default: ModalSlot<DefaultSlotProps>
+    [key: string]: ModalSlot
   }
 
   id?: symbol

--- a/docs/content/3.api/2.composables/1.use-modal.md
+++ b/docs/content/3.api/2.composables/1.use-modal.md
@@ -42,7 +42,7 @@ const modalInstance = useModal<
     onClosed() { /* on closed */ },
   },
   slots: {
-    defaults: '<p>The content of the modal</p>'
+    default: '<p>The content of the modal</p>'
   }
 })
 
@@ -101,7 +101,7 @@ You have to manually calling `modalInstance.destroy()`{lang=ts} whenever you no 
           modalInstance.destroy()
         },
       },
-      slots: { defaults: '<p>The content of the modal</p>' }
+      slots: { default: '<p>The content of the modal</p>' }
     })
 
     modalInstance.open()
@@ -136,7 +136,7 @@ You have to manually calling `modalInstance.destroy()`{lang=ts} whenever you no 
           modalInstance.destroy()
         },
       },
-      slots: { defaults: '<p>The content of the modal</p>' }
+      slots: { default: '<p>The content of the modal</p>' }
     })
 
     modalInstance.open()

--- a/docs/content/3.api/2.composables/1.use-modal.md
+++ b/docs/content/3.api/2.composables/1.use-modal.md
@@ -24,13 +24,12 @@ import { ModalsContainer } from 'vue-final-modal'
 ## Usage
 
 ```ts
-import { markRaw } from 'vue'
 import { VueFinalModal, useModal } from 'vue-final-modal'
 
 const modalInstance = useModal<
   InstanceType<typeof VueFinalModal>['$props']
 >({
-  component: markRaw(VueFinalModal),
+  component: VueFinalModal,
   attrs: {
     // Props
     displayDirective: 'if',
@@ -90,14 +89,13 @@ You have to manually calling `modalInstance.destroy()`{lang=ts} whenever you no 
 - Then you can using `useModal()`{lang=ts} everywhere by given the same `vfm` instance to `options.context`{lang=ts}:
   ```ts
   // Anywhere outside out script setup
-  import { markRaw } from 'vue'
   import { VueFinalModal, useModal } from 'vue-final-modal'
   import { vfm } from '@/plugins/vue-final-modal'
 
   export function openConfirmModal() {
     const modalInstance = useModal({
       context: vfm,
-      component: markRaw(MyConfirmModal),
+      component: MyConfirmModal,
       attrs: {
         onClosed() {
           modalInstance.destroy()
@@ -126,14 +124,13 @@ You have to manually calling `modalInstance.destroy()`{lang=ts} whenever you no 
 - Then you can using `useModal()`{lang=ts} everywhere by given the same `vfm` instance to `options.context`{lang=ts}:
   ```ts
   // Anywhere outside out script setup
-  import { markRaw } from 'vue'
   import { VueFinalModal, useModal } from 'vue-final-modal'
   import { vfm } from '@/plugins/vue-final-modal'
 
   export function openConfirmModal() {
     const modalInstance = useModal({
       context: vfm,
-      component: markRaw(MyConfirmModal),
+      component: MyConfirmModal,
       attrs: {
         onClosed() {
           modalInstance.destroy()

--- a/examples/nuxt3/components/MyModalPreview.vue
+++ b/examples/nuxt3/components/MyModalPreview.vue
@@ -3,7 +3,7 @@ import { useModal } from 'vue-final-modal'
 import MyModal from './MyModal.vue'
 
 const { open } = useModal<InstanceType<typeof MyModal>['$props']>({
-  component: markRaw(MyModal),
+  component: MyModal,
   attrs: {
     title: 'Hello World!',
   },

--- a/examples/vue3/src/components/MyModalPreview.vue
+++ b/examples/vue3/src/components/MyModalPreview.vue
@@ -1,11 +1,10 @@
 <script setup lang="ts">
-import { markRaw } from 'vue'
 import { useModal } from 'vue-final-modal'
 import MyModal from './MyModal.vue'
 import VButton from './VButton.vue'
 
 const { open } = useModal<InstanceType<typeof MyModal>['$props']>({
-  component: markRaw(MyModal),
+  component: MyModal,
   attrs: {
     title: 'Hello World!',
   },

--- a/packages/nuxt/playground/components/showConfirmModal.ts
+++ b/packages/nuxt/playground/components/showConfirmModal.ts
@@ -5,7 +5,7 @@ import PlainCssConfirmModal from './PlainCssConfirmModal.vue'
 export function showConfirmModal(vfm: Vfm) {
   const { open, close, destroy } = useModal({
     context: vfm,
-    component: markRaw(PlainCssConfirmModal),
+    component: PlainCssConfirmModal,
     attrs: {
       title: 'Hello World!',
       onConfirm() {

--- a/packages/vue-final-modal/src/Modal.ts
+++ b/packages/vue-final-modal/src/Modal.ts
@@ -29,14 +29,14 @@ export type UseModalOptionsPrivate<
 }
 
 export type UseModalOptions<
-ModalProps extends ComponentProps,
-DefaultSlotProps extends ComponentProps = {},
+  ModalProps extends ComponentProps,
+  DefaultSlotProps extends ComponentProps = {},
 > = Pick<
-UseModalOptionsPrivate<ModalProps, DefaultSlotProps>,
-| 'context'
-| 'component'
-| 'attrs'
-| 'slots'
+  UseModalOptionsPrivate<ModalProps, DefaultSlotProps>,
+  | 'context'
+  | 'component'
+  | 'attrs'
+  | 'slots'
 >
 
 export type UseModalReturnType<ModalProps extends ComponentProps, DefaultSlotProps extends ComponentProps> = {

--- a/packages/vue-final-modal/src/Modal.ts
+++ b/packages/vue-final-modal/src/Modal.ts
@@ -5,6 +5,11 @@ export type ComponentProps = ComponentPublicInstance['$props']
 export type ModalId = number | string | symbol
 export type StyleValue = string | CSSProperties | (string | CSSProperties)[]
 
+export type ModalSlot<T extends Record<string, any> = {}> = string | {
+  component: Component
+  attrs?: T
+}
+
 export type UseModalOptionsPrivate<
   ModalProps extends ComponentProps = {},
   DefaultSlotProps extends ComponentProps = {},
@@ -13,11 +18,8 @@ export type UseModalOptionsPrivate<
   component: Component
   attrs?: ModalProps
   slots?: {
-    default: string | {
-      component: Component
-      attrs?: DefaultSlotProps
-    }
-    [key: string]: any
+    default: ModalSlot<DefaultSlotProps>
+    [key: string]: ModalSlot
   }
 
   id?: symbol
@@ -26,22 +28,32 @@ export type UseModalOptionsPrivate<
   resolveClosed?: () => void
 }
 
+export type ModalOptions<
+ModalProps extends ComponentProps,
+DefaultSlotProps extends ComponentProps = {},
+> = Pick<
+UseModalOptionsPrivate<ModalProps, DefaultSlotProps>,
+| 'context'
+| 'component'
+| 'attrs'
+| 'slots'
+>
+
 export type UseModalOptions<
   ModalProps extends ComponentProps,
   DefaultSlotProps extends ComponentProps = {},
-> = Pick<
-  UseModalOptionsPrivate<ModalProps, DefaultSlotProps>,
-  | 'context'
-  | 'component'
-  | 'attrs'
-  | 'slots'
->
+> = Omit<ModalOptions<ModalProps, DefaultSlotProps>, 'slots'> & {
+  slots?: {
+    default: ModalSlot<DefaultSlotProps> | Component
+    [key: string]: ModalSlot | Component
+  }
+}
 
 export type UseModalReturnType<ModalProps extends ComponentProps, DefaultSlotProps extends ComponentProps> = {
-  options: UseModalOptions<ModalProps, DefaultSlotProps>
+  options: ModalOptions<ModalProps, DefaultSlotProps>
   open: () => Promise<string>
   close: () => Promise<string>
-  patchOptions: (options: UseModalOptions<ModalProps, DefaultSlotProps>) => void
+  patchOptions: (options: ModalOptions<ModalProps, DefaultSlotProps>) => void
   destroy: () => void
 }
 

--- a/packages/vue-final-modal/src/Modal.ts
+++ b/packages/vue-final-modal/src/Modal.ts
@@ -5,7 +5,7 @@ export type ComponentProps = ComponentPublicInstance['$props']
 export type ModalId = number | string | symbol
 export type StyleValue = string | CSSProperties | (string | CSSProperties)[]
 
-export type ModalSlot<T extends Record<string, any> = {}> = string | {
+export type ModalSlot<T extends Record<string, any> = {}> = string | Component | {
   component: Component
   attrs?: T
 }
@@ -28,7 +28,7 @@ export type UseModalOptionsPrivate<
   resolveClosed?: () => void
 }
 
-export type ModalOptions<
+export type UseModalOptions<
 ModalProps extends ComponentProps,
 DefaultSlotProps extends ComponentProps = {},
 > = Pick<
@@ -39,21 +39,11 @@ UseModalOptionsPrivate<ModalProps, DefaultSlotProps>,
 | 'slots'
 >
 
-export type UseModalOptions<
-  ModalProps extends ComponentProps,
-  DefaultSlotProps extends ComponentProps = {},
-> = Omit<ModalOptions<ModalProps, DefaultSlotProps>, 'slots'> & {
-  slots?: {
-    default: ModalSlot<DefaultSlotProps> | Component
-    [key: string]: ModalSlot | Component
-  }
-}
-
 export type UseModalReturnType<ModalProps extends ComponentProps, DefaultSlotProps extends ComponentProps> = {
-  options: ModalOptions<ModalProps, DefaultSlotProps>
+  options: UseModalOptions<ModalProps, DefaultSlotProps>
   open: () => Promise<string>
   close: () => Promise<string>
-  patchOptions: (options: ModalOptions<ModalProps, DefaultSlotProps>) => void
+  patchOptions: (options: UseModalOptions<ModalProps, DefaultSlotProps>) => void
   destroy: () => void
 }
 

--- a/packages/vue-final-modal/src/components/ModalsContainer.vue
+++ b/packages/vue-final-modal/src/components/ModalsContainer.vue
@@ -30,8 +30,12 @@ onBeforeUnmount(() => {
         <div v-if="isString(slot)" v-html="slot" />
         <component
           :is="slot.component"
-          v-else
+          v-else-if="'component' in slot"
           v-bind="slot.attrs"
+        />
+        <component
+          :is="slot"
+          v-else
         />
       </template>
     </component>

--- a/packages/vue-final-modal/src/components/ModalsContainer.vue
+++ b/packages/vue-final-modal/src/components/ModalsContainer.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount } from 'vue'
+import { isString } from '@vueuse/core'
 import { useInternalVfm, useVfm } from '~/useApi'
-import { isString } from '~/utils'
 
 const { modalsContainers, dynamicModals } = useVfm()
 const { resolvedClosed, resolvedOpened } = useInternalVfm()

--- a/packages/vue-final-modal/src/useApi.ts
+++ b/packages/vue-final-modal/src/useApi.ts
@@ -21,8 +21,8 @@ export function useInternalVfm(): InternalVfm {
 }
 
 function withMarkRaw<
-ModalProps extends ComponentProps,
-DefaultSlotProps extends ComponentProps = {},
+  ModalProps extends ComponentProps,
+  DefaultSlotProps extends ComponentProps = {},
 >(options: UseModalOptions<ModalProps, DefaultSlotProps>) {
   const { component, slots: innerSlots, ...rest } = options
 
@@ -53,9 +53,9 @@ DefaultSlotProps extends ComponentProps = {},
  * Define a dynamic modal.
  */
 function defineModal<
-    ModalProps extends ComponentProps,
-    DefaultSlotProps extends ComponentProps = {},
-  >(_options: UseModalOptions<ModalProps, DefaultSlotProps>): UseModalReturnType<ModalProps, DefaultSlotProps> {
+  ModalProps extends ComponentProps,
+  DefaultSlotProps extends ComponentProps = {},
+>(_options: UseModalOptions<ModalProps, DefaultSlotProps>): UseModalReturnType<ModalProps, DefaultSlotProps> {
   const options = reactive({
     id: Symbol('useModal'),
     modelValue: false,

--- a/packages/vue-final-modal/src/useApi.ts
+++ b/packages/vue-final-modal/src/useApi.ts
@@ -1,9 +1,8 @@
-import { tryOnUnmounted } from '@vueuse/core'
+import { isString, tryOnUnmounted } from '@vueuse/core'
 import { computed, inject, markRaw, reactive, useAttrs } from 'vue'
 import type CoreModal from './components/CoreModal/CoreModal.vue'
 import { internalVfmSymbol, vfmSymbol } from './injectionSymbols'
 import type { ComponentProps, InternalVfm, ModalSlot, UseModalOptions, UseModalOptionsPrivate, UseModalReturnType, Vfm } from './Modal'
-import { isString } from './utils'
 
 /**
  * Returns the vfm instance. Equivalent to using `$vfm` inside

--- a/packages/vue-final-modal/src/utils.ts
+++ b/packages/vue-final-modal/src/utils.ts
@@ -12,7 +12,3 @@ export const noop = () => {}
 export function clamp(val: number, min: number, max: number) {
   return val > max ? max : val < min ? min : val
 }
-
-export function isString(str: any): str is string {
-  return typeof str === 'string'
-}

--- a/viteplay/src/components/ModalBottom/Basic.example.vue
+++ b/viteplay/src/components/ModalBottom/Basic.example.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { markRaw, ref } from 'vue'
+import { ref } from 'vue'
 import { ModalBottom, ModalsContainer, useModal, useVfm } from 'vue-final-modal'
 import DefaultSlot from '../DefaultSlot.vue'
 
@@ -12,7 +12,7 @@ const bottomSheet = useModal<
   InstanceType<typeof ModalBottom>['$props'],
   InstanceType<typeof DefaultSlot>['$props']
 >({
-  component: markRaw(ModalBottom),
+  component: ModalBottom,
   attrs: {
     background: 'interactive',
     contentStyle: {
@@ -21,7 +21,7 @@ const bottomSheet = useModal<
   },
   slots: {
     default: {
-      component: markRaw(DefaultSlot),
+      component: DefaultSlot,
       attrs: {
         text: '123',
         onCreate() {

--- a/viteplay/src/components/ModalFullscreen/Basic.example.vue
+++ b/viteplay/src/components/ModalFullscreen/Basic.example.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { markRaw, ref } from 'vue'
+import { ref } from 'vue'
 import { ModalFullscreen, ModalsContainer, useModal, useVfm } from 'vue-final-modal'
 import DefaultSlot from '../DefaultSlot.vue'
 
@@ -11,7 +11,7 @@ const fullscreenModal = useModal<
     InstanceType<typeof ModalFullscreen>['$props'],
     InstanceType<typeof DefaultSlot>['$props']
   >({
-    component: markRaw(ModalFullscreen),
+    component: ModalFullscreen,
     attrs: {
       background: 'interactive',
       closeDirection: 'RIGHT',
@@ -22,7 +22,7 @@ const fullscreenModal = useModal<
     },
     slots: {
       default: {
-        component: markRaw(DefaultSlot),
+        component: DefaultSlot,
         attrs: {
           text: '123',
 

--- a/viteplay/src/components/VueFinalModal/Basic.example.vue
+++ b/viteplay/src/components/VueFinalModal/Basic.example.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { markRaw, onMounted, ref } from 'vue'
+import { onMounted, ref } from 'vue'
 import { ModalsContainer, VueFinalModal, useModal, useVfm } from 'vue-final-modal'
 import DefaultSlot from '../DefaultSlot.vue'
 import TestModal from './TestModal.vue'
@@ -10,7 +10,7 @@ const modal1 = useModal<
   InstanceType<typeof VueFinalModal>['$props'],
   InstanceType<typeof DefaultSlot>['$props']
 >({
-  component: markRaw(VueFinalModal),
+  component: VueFinalModal,
   attrs: {
     'displayDirective': 'if',
     'background': 'interactive',
@@ -26,7 +26,7 @@ const modal1 = useModal<
   },
   slots: {
     default: {
-      component: markRaw(DefaultSlot),
+      component: DefaultSlot,
       attrs: {
         text: '123',
         onCreate() {
@@ -40,7 +40,7 @@ const modal1 = useModal<
 const modal2 = useModal<
   InstanceType<typeof VueFinalModal>['$props']
 >({
-  component: markRaw(VueFinalModal),
+  component: VueFinalModal,
   attrs: {
     displayDirective: 'if',
     background: 'interactive',


### PR DESCRIPTION
In current, `useModal` usage like following code:

```vue
<script setup lang="ts">
import { markRaw } from 'vue'
import { VueFinalModal, useModal } from 'vue-final-modal'

const modalInstance = useModal({
  component: markRaw(VueFinalModal),
  slots: {
    // pass a html string
    default: '<p>The content of the modal</p>',

    // pass a object include `component` and optional `attrs`
    default: {
      component: markRaw(CustomComponent),
      attrs: {
        // <CustomComponent />'s  props
      }
    }
  }
})
</script>
```

This PR improves two features:

1. Users no longer need to use `markRaw` to wrapper component.
2. `slots` allow passing slot name and components directly.

The following code is new usage after this PR

```vue
<script setup lang="ts">
import { markRaw } from 'vue'
import { VueFinalModal, useModal } from 'vue-final-modal'

const modalInstance = useModal({
  component: VueFinalModal,
  slots: {
    // pass a html string
    default: '<p>The content of the modal</p>',

    // pass a object include `component` and optional `attrs`
    default: {
      component: CustomComponent,
      attrs: {
        // <CustomComponent />'s  props
      }
    },

    // pass a component directly
    default: CustomComponent,
  }
})
</script>
```