### PR TITLE
fix: use shallowRef instead of ref

### DIFF
--- a/packages/vue-final-modal/src/components/ModalsContainer.vue
+++ b/packages/vue-final-modal/src/components/ModalsContainer.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onBeforeUnmount, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, shallowRef, watch } from 'vue'
 import { isString } from '@vueuse/core'
 import type { Ref } from 'vue'
 import type { UseModalOptionsPrivate } from '../Modal'
@@ -11,7 +11,7 @@ const { resolvedClosed, resolvedOpened } = useInternalVfm()
 const uid = Symbol('ModalsContainer')
 const shouldMount = computed(() => uid === modalsContainers.value[0])
 
-const openedDynamicModals: Ref<UseModalOptionsPrivate[]> = ref([])
+const openedDynamicModals: Ref<UseModalOptionsPrivate[]> = shallowRef([])
 
 function syncOpenDynamicModals() {
   openedDynamicModals.value = dynamicModals.filter(modal => modal.modelValue)


### PR DESCRIPTION
When using `vue-final-modal@4.0.0-rc.9` in nuxt with `@vue-final-modal/nuxt@rc`, the following error will be thrown

```
Vue received a Component which was made a reactive object. This can lead to unnecessary performance overhead, and should be avoided by marking the component with `markRaw` or using `shallowRef` instead of `ref`.
```

This PR respects the vue development warning, use `shallowRef` instead of `ref`.
