### PR TITLE
Added closing modal, for action after closing event

### DIFF
--- a/lib/VueFinalModal.vue
+++ b/lib/VueFinalModal.vue
@@ -539,7 +539,8 @@ export default {
         type: eventType,
         stop() {
           stopEvent = true
-        }
+        },
+        close: close
       })
       emit(eventType, event)
       if (stopEvent) {


### PR DESCRIPTION
I wanted to make a modal to confirm the closing of the modal. but the before-closing event does not allow waiting, and therefore I need to either immediately close the modal or not close it again.

Here is an example of a modal of what I wanted to do:

App.vue
```
<script setup>
import { ModalsContainer } from "../../dist/VueFinalModal.esm";
import {default_modal} from "./functions";
</script>

<template>
  <button @click="default_modal">open</button>
  <ModalsContainer></ModalsContainer>
</template>
```

functions.js
```
import {$vfm} from "../../dist/VueFinalModal.esm";
import ConfirmModal from "./components/ConfirmModal.vue";
import TestModal from "./components/TestModal.vue";

export function confirm_modal(text){
    return new Promise((resolve, reject) => {
        $vfm.show({
            component: ConfirmModal,
            slots: {
                text,
            },
            on: {
                // event by custom-modal
                confirm(close) {
                  close()
                  return resolve(true);
                },
                cancel(close) {
                  close()
                  return resolve(false);
                },
            }
        })
    })
}

export function default_modal(){
    $vfm.show({
        component: TestModal,
    })
}
```
ConfirmModal.vue
```
<template>
    <Modal>
        <template #default>
            <slot name="text"></slot>
        </template>
        <template #action="{close}">
            <button type="button" @click="$emit('cancel', close)">Cancel</button>
            <button type="button" @click="$emit('confirm', close)">Do it!</button>
        </template>
    </Modal>
</template>
<script setup>
    import Modal from './Modal.vue';
</script>
```
TestModal.vue
```
<template>
    <Modal @before-close="check">
        Test
    </Modal>
</template>
<script setup>
    import Modal from './Modal.vue';

    import {confirm_modal} from "../functions";

    const check = async event => {
          event.stop();
          if(await confirm_modal(`Close?`)){
            event.close();
          }
    }
</script>
```
Modal.vue
```
<template>
    <vue-final-modal classes="modal-container" content-class="modal-content" v-slot="{close}">
      <button class="modal__close" @click="close">X</button>
      <span class="modal__title">Hello, vue-final-modal</span>
      <div class="modal__content">
        <slot></slot>
      </div>
      <div class="modal__action">
        <slot name="action" :close="close"></slot>
      </div>
    </vue-final-modal>
</template>
<script setup>
import {VueFinalModal } from "../../../dist/VueFinalModal.esm";
</script>
<style scoped>
::v-deep .modal-container {
  display: flex;
  justify-content: center;
  align-items: center;
}
::v-deep .modal-content {
  position: relative;
  display: flex;
  flex-direction: column;
  max-height: 90%;
  margin: 0 1rem;
  padding: 1rem;
  border: 1px solid #e2e8f0;
  border-radius: 0.25rem;
  background: #fff;
}
.modal__title {
  margin: 0 2rem 0 0;
  font-size: 1.5rem;
  font-weight: 700;
}
.modal__content {
  flex-grow: 1;
  overflow-y: auto;
}
.modal__action {
  display: flex;
  justify-content: center;
  align-items: center;
  flex-shrink: 0;
  padding: 1rem 0 0;
}
.modal__close {
  position: absolute;
  top: 0.5rem;
  right: 0.5rem;
}
</style>

<style scoped>
.dark-mode div::v-deep .modal-content {
  border-color: #2d3748;
  background-color: #1a202c;
}
</style>
```

P.S. if it can be done in some other way, I'll be glad to see it