### PR TITLE
fix: should display type error when using `useModal()` #323

### DIFF
--- a/packages/vue-final-modal/src/Modal.ts
+++ b/packages/vue-final-modal/src/Modal.ts
@@ -1,5 +1,4 @@
 import type { App, CSSProperties, Component, ComponentPublicInstance, ComputedRef, Raw, Ref, VNodeProps } from 'vue'
-import type { VueFinalModal } from '.'
 
 export type ComponentProps = ComponentPublicInstance['$props']
 
@@ -27,9 +26,8 @@ export type UseModalOptions<P> = {
   defaultModelValue?: boolean
   context?: Vfm
   component?: Constructor<P>
-  attrs?: (RawProps & P) | ({} extends P ? InstanceType<typeof VueFinalModal>['$props'] : never)
+  attrs?: (RawProps & P) | ({} extends P ? null : never)
   slots?: {
-    default: ModalSlot
     [key: string]: ModalSlot
   }
 }

--- a/packages/vue-final-modal/src/Modal.ts
+++ b/packages/vue-final-modal/src/Modal.ts
@@ -1,4 +1,4 @@
-import type { App, CSSProperties, Component, ComponentOptions, ComponentPublicInstance, ComputedRef, ConcreteComponent, Raw, Ref, VNodeProps } from 'vue'
+import type { App, CSSProperties, Component, ComponentPublicInstance, ComputedRef, Raw, Ref, VNodeProps } from 'vue'
 import type { VueFinalModal } from '.'
 
 export type ComponentProps = ComponentPublicInstance['$props']
@@ -6,65 +6,33 @@ export type ComponentProps = ComponentPublicInstance['$props']
 export type ModalId = number | string | symbol
 export type StyleValue = string | CSSProperties | (string | CSSProperties)[]
 
-type RawProps = VNodeProps & {
+export interface Constructor<P = any> {
+  __isFragment?: never
+  __isTeleport?: never
+  __isSuspense?: never
+  new (...args: any[]): { $props: P }
+}
+
+export type RawProps = VNodeProps & {
   // used to differ from a single VNode object as children
   __v_isVNode?: never
   // used to differ from Array children
   [Symbol.iterator]?: never
 } & Record<string, any>
 
-type VfmAttrs<P> = (RawProps & P) | ({} extends P ? InstanceType<typeof VueFinalModal>['$props'] : never)
-interface UseModalOptionsConcreteComponent<P> { component?: ConcreteComponent<P>; attrs?: VfmAttrs<P> }
-interface UseModalOptionsComponentOptions<P> { component?: ComponentOptions<P>; attrs?: VfmAttrs<P> }
-
-type SlotAttrs<P> = (RawProps & P) | ({} extends P ? null : never)
-interface ModalSlotOptionsConcreteComponent<P> { component: ConcreteComponent<P>; attrs?: SlotAttrs<P> }
-interface ModalSlotOptionsComponentOptions<P> { component: ComponentOptions<P>; attrs?: SlotAttrs<P> }
-
 export interface ModalSlotOptions { component: Raw<Component>; attrs?: Record<string, any> }
 export type ModalSlot = string | Component | ModalSlotOptions
 
-export type UseModalOptionsSlots = {
+export type UseModalOptions<P> = {
+  defaultModelValue?: boolean
+  context?: Vfm
+  component?: Constructor<P>
+  attrs?: (RawProps & P) | ({} extends P ? InstanceType<typeof VueFinalModal>['$props'] : never)
   slots?: {
     default: ModalSlot
     [key: string]: ModalSlot
   }
 }
-
-export type UseModalOptions = {
-  defaultModelValue?: boolean
-  context?: Vfm
-  component?: Raw<Component>
-  attrs?: Record<string, any>
-} & UseModalOptionsSlots
-
-export interface IOverloadedUseModalFn {
-  <P>(options: UseModalOptionsConcreteComponent<P> & UseModalOptionsSlots): UseModalReturnType
-  <P>(options: UseModalOptionsComponentOptions<P> & UseModalOptionsSlots): UseModalReturnType
-  <P>(options:
-  | UseModalOptionsConcreteComponent<P> & UseModalOptionsSlots
-  | UseModalOptionsComponentOptions<P> & UseModalOptionsSlots
-  | UseModalOptions
-  ): UseModalReturnType
-}
-
-interface IOverloadedPatchOptionsFn {
-  <P>(options: UseModalOptionsConcreteComponent<P> & UseModalOptionsSlots): void
-  <P>(options: UseModalOptionsComponentOptions<P> & UseModalOptionsSlots): void
-  <P>(options:
-  | UseModalOptionsConcreteComponent<P> & UseModalOptionsSlots
-  | UseModalOptionsComponentOptions<P> & UseModalOptionsSlots
-  | Omit<UseModalOptions, 'defaultModelValue' | 'context'>
-  ): void
-}
-
-interface IOverloadedUseModalSlotFn {
-  <P>(options: ModalSlotOptionsConcreteComponent<P>): ModalSlot
-  <P>(options: ModalSlotOptionsComponentOptions<P>): ModalSlot
-  <P>(options: ModalSlotOptionsConcreteComponent<P> | ModalSlotOptionsComponentOptions<P> | ModalSlot): ModalSlot
-}
-
-export const useModalSlot: IOverloadedUseModalSlotFn = (options: ModalSlot): ModalSlot => options
 
 export type UseModalOptionsPrivate = {
   id: symbol
@@ -73,11 +41,11 @@ export type UseModalOptionsPrivate = {
   resolveClosed: () => void
 }
 
-export interface UseModalReturnType {
-  options: UseModalOptions & UseModalOptionsPrivate
+export interface UseModalReturnType<P> {
+  options: UseModalOptions<P> & UseModalOptionsPrivate
   open: () => Promise<string>
   close: () => Promise<string>
-  patchOptions: IOverloadedPatchOptionsFn
+  patchOptions: (options: Partial<Omit<UseModalOptions<P>, 'defaultModelValue' | 'context'>>) => void
   destroy: () => void
 }
 
@@ -85,7 +53,7 @@ export type Vfm = {
   install(app: App): void
   modals: ComputedRef<Modal>[]
   openedModals: ComputedRef<Modal>[]
-  dynamicModals: (UseModalOptions & UseModalOptionsPrivate)[]
+  dynamicModals: (UseModalOptions<any> & UseModalOptionsPrivate)[]
   modalsContainers: Ref<symbol[]>
   get: (modalId: ModalId) => undefined | ComputedRef<Modal>
   toggle: (modalId: ModalId, show?: boolean) => undefined | Promise<string>

--- a/packages/vue-final-modal/src/components/ModalsContainer.vue
+++ b/packages/vue-final-modal/src/components/ModalsContainer.vue
@@ -11,7 +11,7 @@ const _vfm = useInternalVfm()
 const uid = Symbol('ModalsContainer')
 const shouldMount = computed(() => uid === vfm.modalsContainers.value?.[0])
 
-const openedDynamicModals: Ref<(UseModalOptions & UseModalOptionsPrivate)[]> = shallowRef([])
+const openedDynamicModals: Ref<(UseModalOptions<any> & UseModalOptionsPrivate)[]> = shallowRef([])
 
 function syncOpenDynamicModals() {
   openedDynamicModals.value = vfm.dynamicModals.filter(modal => modal.modelValue)

--- a/packages/vue-final-modal/src/plugin.ts
+++ b/packages/vue-final-modal/src/plugin.ts
@@ -6,7 +6,7 @@ import type { InternalVfm, Modal, ModalId, UseModalOptions, UseModalOptionsPriva
 export function createVfm() {
   const modals: ComputedRef<Modal>[] = shallowReactive([])
   const openedModals: ComputedRef<Modal>[] = shallowReactive([])
-  const dynamicModals: (UseModalOptions & UseModalOptionsPrivate)[] = shallowReactive([])
+  const dynamicModals: (UseModalOptions<any> & UseModalOptionsPrivate)[] = shallowReactive([])
   const modalsContainers = ref<symbol[]>([])
 
   const vfm: Vfm = markRaw({

--- a/packages/vue-final-modal/src/useApi.ts
+++ b/packages/vue-final-modal/src/useApi.ts
@@ -1,6 +1,6 @@
 import { isString, tryOnUnmounted } from '@vueuse/core'
 import { computed, getCurrentInstance, inject, markRaw, reactive, useAttrs } from 'vue'
-import type { Component, Raw } from 'vue'
+import type { Component } from 'vue'
 import VueFinalModal from './components/VueFinalModal/VueFinalModal.vue'
 import type CoreModal from './components/CoreModal/CoreModal.vue'
 import { internalVfmSymbol, vfmSymbol } from './injectionSymbols'
@@ -43,7 +43,7 @@ function withMarkRaw<P>(options: Partial<UseModalOptions<P>>, DefaultComponent: 
 
   return {
     ...rest,
-    component: markRaw(component || DefaultComponent),
+    component: markRaw(component || DefaultComponent) as Constructor<P>,
     slots,
   }
 }
@@ -51,12 +51,12 @@ function withMarkRaw<P>(options: Partial<UseModalOptions<P>>, DefaultComponent: 
 /**
  * Create a dynamic modal.
  */
-export function useModal<P>(_options: UseModalOptions<P>): UseModalReturnType<P> {
+export function useModal<P = InstanceType<typeof VueFinalModal>['$props']>(_options: UseModalOptions<P>): UseModalReturnType<P> {
   const options = reactive({
     id: Symbol('useModal'),
     modelValue: !!_options?.defaultModelValue,
-    resolveOpened: () => {},
-    resolveClosed: () => {},
+    resolveOpened: () => { },
+    resolveClosed: () => { },
     attrs: {},
     ...withMarkRaw<P>(_options),
   }) as UseModalOptions<P> & UseModalOptionsPrivate
@@ -147,12 +147,10 @@ function patchAttrs<T extends Record<string, any>>(attrs: T, newAttrs: Partial<T
   return attrs
 }
 
-type ComponentOptions = {
-  component?: Raw<Component>
-  attrs?: Record<string, any>
-}
-
-function patchComponentOptions(options: ComponentOptions | ModalSlotOptions, newOptions: ComponentOptions | ModalSlotOptions) {
+function patchComponentOptions<P>(
+  options: Omit<UseModalOptions<P>, 'defaultModelValue' | 'context'> | ModalSlotOptions,
+  newOptions: Partial<Omit<UseModalOptions<P>, 'defaultModelValue' | 'context'>> | ModalSlotOptions,
+) {
   if (newOptions.component)
     options.component = newOptions.component
 


### PR DESCRIPTION
fixed #323

1. This is the fixed version that shows type error:

<img width="545" alt="image" src="https://user-images.githubusercontent.com/15190246/217758952-6c6da14c-9e29-43fd-ac02-b4e6e0c5a906.png">

2. [ ] Still has issue without given `options.component`:
This is incorrect:
<img width="581" alt="image" src="https://user-images.githubusercontent.com/15190246/217759630-e7c54c6d-a4eb-412f-af8a-33458bfc194d.png">
Should be: 
<img width="690" alt="image" src="https://user-images.githubusercontent.com/15190246/217759976-67b1ad1f-857b-45f6-a1c5-02ff90718f32.png">
