### PR TITLE
feat: get rid of context and made useModal can be execute everywhere

### DIFF
--- a/docs/content/2.get-started/1.guide/4.types.md
+++ b/docs/content/2.get-started/1.guide/4.types.md
@@ -33,7 +33,6 @@ export type ModalSlot = string | Component | ModalSlotOptions
 export type UseModalOptions<P> = {
   defaultModelValue?: boolean
   keepAlive?: boolean
-  context?: Vfm
   component?: Constructor<P>
   attrs?: (RawProps & P) | ({} extends P ? null : never)
   slots?: {

--- a/packages/vue-final-modal/cypress/components/focusTrap.spec.ts
+++ b/packages/vue-final-modal/cypress/components/focusTrap.spec.ts
@@ -7,7 +7,6 @@ describe('Test focusTrap', () => {
     const vfm = createVfm()
 
     const firstModal = useModal({
-      context: vfm,
       component: VueFinalModal,
       attrs: { contentClass: 'first-modal-content' },
       slots: {
@@ -16,7 +15,6 @@ describe('Test focusTrap', () => {
     })
 
     const secondModal = useModal({
-      context: vfm,
       component: VueFinalModal,
       attrs: { contentClass: 'second-modal-content' },
       slots: {

--- a/packages/vue-final-modal/cypress/components/useModal.spec.ts
+++ b/packages/vue-final-modal/cypress/components/useModal.spec.ts
@@ -6,7 +6,6 @@ describe('Test useModal()', () => {
   it('Should be closed by default', () => {
     const vfm = createVfm()
     const modal = useModal({
-      context: vfm,
       slots: { default: 'Hello World!' },
     })
 
@@ -25,7 +24,6 @@ describe('Test useModal()', () => {
   it('Should be opened by given defaultModelValue: true', () => {
     const vfm = createVfm()
     useModal({
-      context: vfm,
       defaultModelValue: true,
       slots: {
         default: 'Hello World!',
@@ -51,7 +49,6 @@ describe('Test useModal()', () => {
     const onClosed = cy.spy().as('onClosed')
 
     const modal = useModal({
-      context: vfm,
       attrs: {
         onBeforeOpen,
         onOpened,

--- a/packages/vue-final-modal/cypress/components/useZIndex.spec.ts
+++ b/packages/vue-final-modal/cypress/components/useZIndex.spec.ts
@@ -5,19 +5,16 @@ describe('Test useZIndex()', () => {
   it('Props: zIndexFn()', () => {
     const vfm = createVfm()
     const firstModal = useModal({
-      context: vfm,
       component: VueFinalModal,
       attrs: { class: 'first-modal' },
     })
 
     const secondModal = useModal({
-      context: vfm,
       component: VueFinalModal,
       attrs: { class: 'second-modal' },
     })
 
     const thirdModal = useModal({
-      context: vfm,
       component: VueFinalModal,
       attrs: { class: 'third-modal' },
     })

--- a/packages/vue-final-modal/src/Modal.ts
+++ b/packages/vue-final-modal/src/Modal.ts
@@ -25,7 +25,6 @@ export type ModalSlot = string | Component | ModalSlotOptions
 export type UseModalOptions<P> = {
   defaultModelValue?: boolean
   keepAlive?: boolean
-  context?: Vfm
   component?: Constructor<P>
   attrs?: (RawProps & P) | ({} extends P ? null : never)
   slots?: {

--- a/packages/vue-final-modal/src/plugin.ts
+++ b/packages/vue-final-modal/src/plugin.ts
@@ -21,8 +21,6 @@ export function createVfm() {
 
   const vfm: Vfm = markRaw({
     install(app: App) {
-      setActiveVfm(vfm)
-
       app.provide(vfmSymbol, vfm)
       app.config.globalProperties.$vfm = vfm
 

--- a/packages/vue-final-modal/src/useApi.ts
+++ b/packages/vue-final-modal/src/useApi.ts
@@ -6,7 +6,7 @@ import type CoreModal from './components/CoreModal/CoreModal.vue'
 import { internalVfmSymbol } from './injectionSymbols'
 
 import type { ComponentProps, Constructor, InternalVfm, ModalSlot, ModalSlotOptions, RawProps, UseModalOptions, UseModalOptionsPrivate, UseModalReturnType, Vfm } from './Modal'
-import { activeVfm, getActiveVfm } from './plugin'
+import { getActiveVfm } from './plugin'
 
 /**
  * Returns the vfm instance. Equivalent to using `$vfm` inside
@@ -14,8 +14,14 @@ import { activeVfm, getActiveVfm } from './plugin'
  */
 export function useVfm(): Vfm {
   const vfm = getActiveVfm()
-  if (__DEV__ && !vfm)
-    consoleError()
+  if (__DEV__ && !vfm) {
+    throw new Error(
+      '[Vue Final Modal]: getActiveVfm was called with no active Vfm. Did you forget to install vfm?\n'
+        + '\tconst vfm = createVfm()\n'
+        + '\tapp.use(vfm)\n'
+        + 'This will fail in production.',
+    )
+  }
 
   return vfm!
 }
@@ -80,10 +86,6 @@ export function useModal<P = InstanceType<typeof VueFinalModal>['$props']>(_opti
   async function open(): Promise<string> {
     await nextTick()
     const vfm = useVfm()
-    if (!vfm) {
-      consoleError()
-      return Promise.resolve('error')
-    }
     if (options.modelValue)
       return Promise.resolve('[Vue Final Modal] modal is already opened.')
 
@@ -152,10 +154,6 @@ export function useModal<P = InstanceType<typeof VueFinalModal>['$props']>(_opti
 
   function destroy(): void {
     const vfm = useVfm()
-    if (!vfm) {
-      consoleError()
-      return
-    }
     const index = vfm.dynamicModals.indexOf(options)
     if (index !== -1)
       vfm.dynamicModals.splice(index, 1)
@@ -220,15 +218,4 @@ export function useVfmAttrs(options: {
   }))
 
   return vfmAttrs
-}
-
-function consoleError() {
-  if (__DEV__ && !activeVfm) {
-    throw new Error(
-      '[Vue Final Modal]: getActiveVfm was called with no active Vfm. Did you forget to install vfm?\n'
-        + '\tconst vfm = createVfm()\n'
-        + '\tapp.use(vfm)\n'
-        + 'This will fail in production.',
-    )
-  }
 }

--- a/viteplay/src/components/VueFinalModal/Basic.example.vue
+++ b/viteplay/src/components/VueFinalModal/Basic.example.vue
@@ -2,10 +2,13 @@
 import { ref } from 'vue'
 import { ModalsContainer, VueFinalModal, useModal, useModalSlot, useVfm } from 'vue-final-modal'
 import DefaultSlot from '../DefaultSlot.vue'
+import { modal } from './modalsHelpers'
 import TestModal from './TestModal.vue'
 
-const { toggle, closeAll } = useVfm()
+console.log('modal → ', modal)
 
+const { toggle, closeAll } = useVfm()
+// modal.open()
 const modal1 = useModal({
   keepAlive: true,
   component: VueFinalModal,

--- a/viteplay/src/components/VueFinalModal/Basic.example.vue
+++ b/viteplay/src/components/VueFinalModal/Basic.example.vue
@@ -8,7 +8,10 @@ import TestModal from './TestModal.vue'
 console.log('modal → ', modal)
 
 const { toggle, closeAll } = useVfm()
-// modal.open()
+modal.open().then((res) => { console.log('res', res) })
+modal.open().then((res) => { console.log('res', res) })
+modal.open().then((res) => { console.log('res', res) })
+modal.open().then((res) => { console.log('res', res) })
 const modal1 = useModal({
   keepAlive: true,
   component: VueFinalModal,

--- a/viteplay/src/components/VueFinalModal/modalsHelpers.ts
+++ b/viteplay/src/components/VueFinalModal/modalsHelpers.ts
@@ -1,0 +1,19 @@
+import { VueFinalModal, useModal, useModalSlot } from 'vue-final-modal'
+import DefaultSlot from '../DefaultSlot.vue'
+
+export const modal = useModal({
+  component: VueFinalModal,
+  // defaultModelValue: true,
+  slots: {
+    default: useModalSlot({
+      component: DefaultSlot,
+      attrs: {
+        text: '123',
+        onCreate() {
+          // console.log('onCreated')
+        },
+      },
+    }),
+  },
+})
+// modal.open()

--- a/viteplay/src/components/VueFinalModal/modalsHelpers.ts
+++ b/viteplay/src/components/VueFinalModal/modalsHelpers.ts
@@ -1,6 +1,7 @@
 import { VueFinalModal, useModal, useModalSlot } from 'vue-final-modal'
 import DefaultSlot from '../DefaultSlot.vue'
 
+console.log('helper')
 export const modal = useModal({
   component: VueFinalModal,
   // defaultModelValue: true,


### PR DESCRIPTION
Made useModal truly allowed to execute everywhere

1. Vfm should provide a way to create a modal instance outside of `setup script`, like a singleton of a dynamic modal, for example:
    ```ts
    // modalHelpers.ts
    export const modalInstance = useModal({
      ...
    })
    ```
    and import the `modalInstance` from else where:
    ```vue
    <script lang="ts" setup>
    import { modalInstance } from './modalHelpers' 
    
    modalInstance.open()
    </script>
    ```
2. Vfm should provide a way to create a modal that opened by default, for example:
    ```ts
    // modalHelpers.ts
    export const modalInstance = useModal({
      defaultModelValue: true,
      ...
    })
    ```
    and also open the modal right after create the modal instance, for example:
    ```ts
    // modalHelpers.ts
    export const modalInstance = useModal({
      ...
    })
    modalInstance.open()
    ```
3. The PR also delete the `context: vfm` and replace it with the `getActiveVfm()` pattern that inspired from `pinia`