### PR TITLE
refactor: resolve the error caused by VueUse removing `isString`

### DIFF
--- a/packages/vue-final-modal/src/components/ModalsContainer.vue
+++ b/packages/vue-final-modal/src/components/ModalsContainer.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount } from 'vue'
-import { isString } from '@vueuse/core'
+import { isString } from '~/utils'
 import { useInternalVfm, useVfm } from '~/useApi'
 
 const vfm = useVfm()

--- a/packages/vue-final-modal/src/useApi.ts
+++ b/packages/vue-final-modal/src/useApi.ts
@@ -1,5 +1,5 @@
 import { computed, inject, markRaw, nextTick, reactive, useAttrs } from 'vue'
-import { isString, tryOnUnmounted } from '@vueuse/core'
+import { tryOnUnmounted } from '@vueuse/core'
 import type { Component } from 'vue'
 import VueFinalModal from './components/VueFinalModal/VueFinalModal.vue'
 import type CoreModal from './components/CoreModal/CoreModal.vue'
@@ -7,6 +7,7 @@ import { internalVfmSymbol } from './injectionSymbols'
 
 import type { ComponentProps, Constructor, InternalVfm, ModalSlot, ModalSlotOptions, RawProps, UseModalOptions, UseModalOptionsPrivate, UseModalReturnType, Vfm } from './Modal'
 import { activeVfm, getActiveVfm } from './plugin'
+import { isString } from '~/utils'
 
 /**
  * Returns the vfm instance. Equivalent to using `$vfm` inside

--- a/packages/vue-final-modal/src/utils.ts
+++ b/packages/vue-final-modal/src/utils.ts
@@ -12,3 +12,5 @@ export const noop = () => {}
 export function clamp(val: number, min: number, max: number) {
   return val > max ? max : val < min ? min : val
 }
+
+export const isString = (value: unknown): value is string => typeof value === 'string'


### PR DESCRIPTION
resolves: https://github.com/vue-final/vue-final-modal/issues/358