### PR TITLE
Implement support for setting the aria-labelledby attribute

### DIFF
--- a/packages/vue-final-modal/src/components/CoreModal/CoreModal.vue
+++ b/packages/vue-final-modal/src/components/CoreModal/CoreModal.vue
@@ -184,6 +184,7 @@ onBeforeUnmount(() => {
     :style="{ zIndex }"
     role="dialog"
     aria-modal="true"
+    :aria-labelledby="ariaLabelledBy"
     @keydown.esc="() => onEsc()"
     @mouseup.self="() => onMouseupRoot()"
     @mousedown.self="e => onMousedown(e)"

--- a/packages/vue-final-modal/src/components/CoreModal/CoreModalProps.ts
+++ b/packages/vue-final-modal/src/components/CoreModal/CoreModalProps.ts
@@ -146,6 +146,14 @@ export const coreModalProps = {
     }),
   },
   /**
+   * @description HTML ID of the header of the dialog, used for the aria-labelledby attribute
+   * @default undefined
+   */
+  ariaLabelledBy: {
+    type: String as PropType<string | undefined>,
+    default: undefined
+  },
+  /**
    * @description Lock body scroll or not when the modal is opened.
    * @default `true`
    */


### PR DESCRIPTION
Resolves #208 

This PR implements support for setting the aria-labelledby attribute, as required by accesibility standards. I have tried to follow existing conventions in the code as closely as possible.