### PR TITLE
feat: add helper function `defineLazyMountComponent`

### DIFF
--- a/packages/vue-final-modal/src/defineLazyMountComponent.ts
+++ b/packages/vue-final-modal/src/defineLazyMountComponent.ts
@@ -1,0 +1,38 @@
+import type {
+  AsyncComponentLoader,
+  AsyncComponentOptions,
+  Component,
+  ComponentPublicInstance,
+} from 'vue'
+
+import {
+  defineAsyncComponent,
+  defineComponent,
+  h,
+} from 'vue'
+
+export function defineLazyMountComponent<
+  T extends Component = {
+    new (): ComponentPublicInstance
+  },
+>(
+  source: AsyncComponentLoader<T> | AsyncComponentOptions<T>,
+): T {
+  return defineComponent({
+    name: 'LazyMountComponent',
+    setup(_, { attrs }) {
+      let mounted = false
+      return () => {
+        if (attrs.modelValue || mounted) {
+          return h(defineAsyncComponent(source), {
+            ...attrs,
+            onVnodeMounted: () => {
+              mounted = true
+            },
+          })
+        }
+        return undefined
+      }
+    },
+  }) as T
+}

--- a/packages/vue-final-modal/src/index.ts
+++ b/packages/vue-final-modal/src/index.ts
@@ -25,6 +25,9 @@ export type { VueFinalModalEmits } from './components/VueFinalModal/VueFinalModa
 /** Composables */
 export { useVfm, useModal, useVfmAttrs, useModalSlot } from './useApi'
 
+/** Helpers */
+export { defineLazyMountComponent } from './defineLazyMountComponent'
+
 declare module '@vue/runtime-core' {
   export interface ComponentCustomProperties {
     /**


### PR DESCRIPTION
Modal are often not opened immediately when entering a website. They usually require some action, like click button to trigger their appearance.

To handle this, we can use `defineAsyncComponent` to load the modal component dynamically:

```vue
<script setup lang="ts">
import { defineAsyncComponent, ref } from 'vue'

const LazyCustomModal = defineAsyncComponent(() => import('@/components/CustomModal.vue'));

const isActive = ref(false)
</script>

<template>
  <LazyCustomModal v-model="isActive"  />
</template>
```

However, this approach only splits the component into a separate chunk, which will still be loaded when entering the page, even if we don't open it.

To achieve delayed loading, we can implement the following:

```vue
<script setup lang="ts">
import { defineAsyncComponent, ref } from 'vue'

const LazyCustomModal = defineAsyncComponent(() => import('@/components/CustomModal.vue'));

const isActive = ref(false)
</script>

<template>
  <template v-if="isActive">
    <LazyCustomModal v-model="isActive"  />
  </template>
</template>
```

But a problem with this method is that the component will be unloaded when the modal is closed. So we need to do something special to handle this:

```vue
<script setup lang="ts">
import { defineAsyncComponent, ref } from 'vue'

const LazyCustomModal = defineAsyncComponent(() => import('@/components/CustomModal.vue'));

const isActive = ref(false)
const isModalMounted = ref(false)
</script>

<template>
  <template v-if="isActive || isModalMounted">
    <LazyCustomModal 
      v-model="isActive"
      @vnode-mounted="isModalMounted = true"
    />
  </template>
</template>
```

This solution might seem a bit wordy, so I attempted to add a new method called `defineLazyMountCompone` to encapsulate the above logic:

```vue
<script setup lang="ts">
import { ref } from 'vue'
import { defineLazyMountComponent } from 'vue-final-modal'

const LazyCustomModal = defineLazyMountComponent(() => import('@/components/CustomModal.vue'));

const isActive = ref(false)
</script>

<template>
  <LazyCustomModal v-model="isActive"  />
</template>
```

I hope this simplified explanation is easier to understand. If you have any questions, feel free to ask!