### PR TITLE
fix: import nuxt composables from #imports

### DIFF
--- a/docs/content/2.get-started/1.guide/3.migration-guide.md
+++ b/docs/content/2.get-started/1.guide/3.migration-guide.md
@@ -37,7 +37,7 @@ app.use(vfm)
 So this:
 
 ```ts [./plugins/vue-final-modal.ts]
-import { defineNuxtPlugin } from '#app'
+import { defineNuxtPlugin } from '#imports'
 import { vfmPlugin } from 'vue-final-modal'
 
 export default defineNuxtPlugin(nuxtApp => {

--- a/packages/nuxt/src/runtime/plugin.ts
+++ b/packages/nuxt/src/runtime/plugin.ts
@@ -1,5 +1,5 @@
 import { createVfm } from 'vue-final-modal'
-import { defineNuxtPlugin } from '#app'
+import { defineNuxtPlugin } from '#imports'
 
 export default defineNuxtPlugin((nuxtApp) => {
   const vfm = createVfm()


### PR DESCRIPTION
This is a DX improvement when developing - we can avoid loading the entire barrel file at `#app` by using the new granular imports merged in https://github.com/nuxt/nuxt/pull/23951.