### PR TITLE
Rename module extension to mjs

### DIFF
--- a/packages/vue-final-modal/package.json
+++ b/packages/vue-final-modal/package.json
@@ -4,11 +4,11 @@
   "version": "4.4.6",
   "source": "src/index.ts",
   "main": "./dist/index.umd.js",
-  "module": "./dist/index.es.js",
+  "module": "./dist/index.es.mjs",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/index.es.js",
+      "import": "./dist/index.es.mjs",
       "require": "./dist/index.umd.js",
       "types": "./dist/index.d.ts"
     },

--- a/packages/vue-final-modal/vite.config.ts
+++ b/packages/vue-final-modal/vite.config.ts
@@ -27,7 +27,7 @@ export default defineConfig({
     lib: {
       entry: path.resolve(__dirname, 'src/index.ts'),
       name,
-      fileName: format => `${name}.${format}.js`,
+      fileName: format => `${name}.${format}.${format === 'es' ? 'm' : ''}js`,
     },
     rollupOptions: {
       external: [


### PR DESCRIPTION
`vue-final-modal` fails to import during SSR because the module is seen as a commonjs module and not an ES module.

More information here:
https://nodejs.org/api/esm.html#resolution-algorithm

Relevant section:
<img width="942" alt="Screenshot 2023-11-11 at 3 09 21 PM" src="https://github.com/vue-final/vue-final-modal/assets/366243/c264912c-1e42-4e75-9dd3-ec2678c30c28">

Here is a minimum example.
https://stackblitz.com/edit/github-4qeonz?file=README.md

In this example `pnpm dev` functions fine, but `pnpm build` fails 
<img width="813" alt="Screenshot 2023-11-11 at 3 09 03 PM" src="https://github.com/vue-final/vue-final-modal/assets/366243/bafbcc8d-db90-40d4-ac2a-70fc210e2955">
