### PR TITLE
Update 1.concepts.md to remove localhost link

### DIFF
--- a/docs/content/2.get-started/1.guide/1.concepts.md
+++ b/docs/content/2.get-started/1.guide/1.concepts.md
@@ -16,7 +16,7 @@ These are the core concepts you need to know about vue-final-modal and its appro
 
 ::list{type=success}
   - SSR (Nuxt 3) support. [Teleport](/api/components/vue-final-modal#teleportto) your modals to `'body'`{lang=ts} by default.
-  - [`useModal()`{lang=ts}](http://localhost:3000/api/composables/use-modal) composable to manage your modal programmatically.
+  - [`useModal()`{lang=ts}](/api/composables/use-modal) composable to manage your modal programmatically.
   - Trap keyboard focus within modal element (uses [focus-trap](https://github.com/focus-trap/focus-trap) for best web accessibility).
   - Full control to the zIndex of the nested modals (see [zIndexFn prop](/api/components/vue-final-modal#zindexfn)).
   - Customizable `<Transition>` for the modal content and overlay.


### PR DESCRIPTION
Was looking through the docs and noticed this link pointed explicitly to a localhost path. Figured it should exclude that to work in the live docs since that page exists. 