### PR TITLE
fix: augment `vue` rather than `@vue/runtime-core`

### DIFF
--- a/packages/vue-final-modal/src/index.ts
+++ b/packages/vue-final-modal/src/index.ts
@@ -23,7 +23,7 @@ export type { VueFinalModalEmits } from './components/VueFinalModal/VueFinalModa
 /** Composables */
 export { useVfm, useModal, useVfmAttrs, useModalSlot } from './useApi'
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   export interface ComponentCustomProperties {
     /**
      * Vue Final Modal global state for the modal components and also provides


### PR DESCRIPTION

In line with https://github.com/vuejs/router/pull/2295 and https://github.com/nuxt/nuxt/pull/28542, this moves to augment `vue` rather than `@vue/runtime` core.

This is now officially recommended [in the docs](https://vuejs.org/api/utility-types.html#componentcustomproperties) and it _must_ be done by all libraries or it will break types for _other_ libraries.