### PR TITLE
fix: patchOptions attrs params type to be partial

### DIFF
--- a/packages/vue-final-modal/src/Modal.ts
+++ b/packages/vue-final-modal/src/Modal.ts
@@ -28,11 +28,15 @@ export type UseModalOptionsPrivate = {
   resolveClosed: () => void
 }
 
+export type ModalPatchOptions<T extends Component> = Partial<UseModalOptions<T>> & {
+  attrs?: Partial<ComponentProps<T>>
+}
+
 export interface UseModalReturnType<T extends Component> {
   options: UseModalOptions<T> & UseModalOptionsPrivate
   open: () => Promise<string>
   close: () => Promise<string>
-  patchOptions: (options: Partial<UseModalOptions<T>>) => void
+  patchOptions: (options: ModalPatchOptions<T>) => void
   destroy: () => void
 }
 


### PR DESCRIPTION
Link to issue: [Enable TypeScript Support for Partial Updates in patchOptions from useModal](https://github.com/vue-final/vue-final-modal/issues/461)