### PR TITLE
Fixed type safety in props for Ref values.

### DIFF
--- a/packages/vue-final-modal/src/Component.ts
+++ b/packages/vue-final-modal/src/Component.ts
@@ -3,13 +3,15 @@
  * Copy from https://github.com/vuejs/language-tools/tree/master/packages/component-type-helpers
  */
 
+import { MaybeRefProps } from '~/utils';
+
 // export type ComponentType<T> =
 // T extends new () => {} ? 1 :
 //   T extends (...args: any) => any ? 2 :
 //     0
 
 export type ComponentProps<T> =
-T extends new () => { $props: infer P } ? NonNullable<P> :
+T extends new () => { $props: infer P } ? MaybeRefProps<NonNullable<P>> :
   T extends (props: infer P, ...args: any) => any ? P :
       {}
 

--- a/packages/vue-final-modal/src/utils.ts
+++ b/packages/vue-final-modal/src/utils.ts
@@ -1,3 +1,5 @@
+import type { Ref } from 'vue'
+
 export const once
   = (fn: null | ((...args: any[]) => void)) =>
     (...args: any[]) => {
@@ -38,4 +40,8 @@ type Entries<T> = { [K in keyof T]: [K, T[K]] }[keyof T][]
  */
 export function objectEntries<T extends Record<any, any>>(object: T): Entries<T> {
   return Object.entries(object) as any
+}
+
+export type MaybeRefProps<P> = {
+  [K in keyof P]: Ref<P[K]> | P[K];
 }


### PR DESCRIPTION
Issue: #468 

## Resolves this problem
```
const reactiveLoading = ref(false)
const { open: openModal, close: closeModal } = useModal({
    component: LoadingComponent,
    attrs: {
        loading: reactiveLoading,
    },
})
```

_Warning_
```
Type 'Ref<boolean, boolean>' is not assignable to type 'boolean'.ts-plugin(2322)
(property) loading: globalThis.Ref<boolean, boolean>
```
<img width="696" alt="Image" src="https://github.com/user-attachments/assets/2ec107d4-8f7f-4cc7-8802-32bd926b28d4" />

## What is Expected?
It should accept both `T` and `Ref<T>`
